### PR TITLE
nit: move response types out of the models package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
         run: go build -v ./...
 
       - name: Format
-        run: test -z $(gofmt -l .)
+        run: test -z "$(gofmt -l .)"
 
       - name: Test
         run: go test -v ./...

--- a/api/answer.go
+++ b/api/answer.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cartabinaria/auth/pkg/httputil"
 	"github.com/cartabinaria/auth/pkg/middleware"
@@ -15,6 +16,24 @@ import (
 	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
 )
+
+type Answer struct {
+	ID        uint      `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	Question uint  `json:"question"`
+	Parent   *uint `json:"parent"`
+
+	User          string           `json:"user"`
+	UserAvatarURL string           `json:"user_avatar_url"`
+	Content       string           `json:"content"`
+	Upvotes       uint32           `json:"upvotes"`
+	Downvotes     uint32           `json:"downvotes"`
+	Replies       []Answer 				 `json:"replies"`
+	CanIDelete    bool             `json:"can_i_delete"`
+	IVoted        VoteValue        `json:"i_voted"`
+}
 
 const RepliesDepth = 2
 
@@ -39,7 +58,7 @@ func createPreloadFunction(votesSubquery *gorm.DB) func(db *gorm.DB) *gorm.DB {
 	}
 }
 
-func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*models.AnswerResponse, error) {
+func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*Answer, error) {
 	db := util.GetDb()
 	usr, err := util.GetUserByID(db, answer.UserId)
 	if err != nil {
@@ -67,7 +86,7 @@ func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*m
 		content = latestVersion.Content
 	}
 
-	var voteValue models.VoteValue
+	var voteValue VoteValue
 	var vote models.Vote
 	err = db.Where("answer = ? AND user_id = ?", answer.ID, requesterID).First(&vote).Error
 	if err != nil {
@@ -77,11 +96,11 @@ func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*m
 			voteValue = VoteNone
 		}
 	} else {
-		voteValue = models.VoteValue(vote.Vote)
+		voteValue = VoteValue(vote.Vote)
 	}
 
 	// recursively convert replies
-	var replies []models.AnswerResponse
+	var replies []Answer
 	for _, reply := range answer.Replies {
 		reply, err := ConvertAnswerToAPI(reply, isAdmin, requesterID)
 		if err != nil {
@@ -90,7 +109,7 @@ func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*m
 		replies = append(replies, *reply)
 	}
 
-	return &models.AnswerResponse{
+	return &Answer{
 		ID:            answer.ID,
 		CreatedAt:     answer.CreatedAt,
 		UpdatedAt:     answer.UpdatedAt,
@@ -113,7 +132,7 @@ func ConvertAnswerToAPI(answer models.Answer, isAdmin bool, requesterID int) (*m
 // @Tags			answer
 // @Param			answerReq	body	models.PostAnswerRequest	true	"Answer data to insert"
 // @Produce		json
-// @Success		200	{object}	models.AnswerResponse
+// @Success		200	{object}	Answer
 // @Failure		400	{object}	httputil.ApiError
 // @Router			/answers [post]
 func PostAnswerHandler(res http.ResponseWriter, req *http.Request) {
@@ -204,8 +223,7 @@ func PostAnswerHandler(res http.ResponseWriter, req *http.Request) {
 		username = user.Username
 	}
 
-	httputil.WriteData(res, http.StatusOK,
-		models.AnswerResponse{
+	httputil.WriteData(res, http.StatusOK, Answer{
 			ID:            answer.ID,
 			CreatedAt:     answer.CreatedAt,
 			UpdatedAt:     answer.UpdatedAt,
@@ -354,7 +372,7 @@ func UpdateAnswerHandler(res http.ResponseWriter, req *http.Request) {
 // @Param			id	path	string	true	"Answer id"
 // @Produce		json
 // @Success		200	{object}	nil
-// @Failure		400	{object}	models.AnswerResponse[]
+// @Failure		400	{object}	Answer[]
 // @Router			/answers/{id}/replies [get]
 func GetRepliesHandler(res http.ResponseWriter, req *http.Request) {
 	// Check method GET is used

--- a/api/answer.go
+++ b/api/answer.go
@@ -25,14 +25,14 @@ type Answer struct {
 	Question uint  `json:"question"`
 	Parent   *uint `json:"parent"`
 
-	User          string           `json:"user"`
-	UserAvatarURL string           `json:"user_avatar_url"`
-	Content       string           `json:"content"`
-	Upvotes       uint32           `json:"upvotes"`
-	Downvotes     uint32           `json:"downvotes"`
-	Replies       []Answer 				 `json:"replies"`
-	CanIDelete    bool             `json:"can_i_delete"`
-	IVoted        VoteValue        `json:"i_voted"`
+	User          string    `json:"user"`
+	UserAvatarURL string    `json:"user_avatar_url"`
+	Content       string    `json:"content"`
+	Upvotes       uint32    `json:"upvotes"`
+	Downvotes     uint32    `json:"downvotes"`
+	Replies       []Answer  `json:"replies"`
+	CanIDelete    bool      `json:"can_i_delete"`
+	IVoted        VoteValue `json:"i_voted"`
 }
 
 const RepliesDepth = 2
@@ -224,19 +224,19 @@ func PostAnswerHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	httputil.WriteData(res, http.StatusOK, Answer{
-			ID:            answer.ID,
-			CreatedAt:     answer.CreatedAt,
-			UpdatedAt:     answer.UpdatedAt,
-			Question:      answer.Question,
-			Parent:        answer.Parent,
-			User:          username,
-			UserAvatarURL: avatar,
-			Content:       version.Content,
-			Upvotes:       answer.Upvotes,
-			Downvotes:     answer.Downvotes,
-			CanIDelete:    true,
-			IVoted:        0,
-		})
+		ID:            answer.ID,
+		CreatedAt:     answer.CreatedAt,
+		UpdatedAt:     answer.UpdatedAt,
+		Question:      answer.Question,
+		Parent:        answer.Parent,
+		User:          username,
+		UserAvatarURL: avatar,
+		Content:       version.Content,
+		Upvotes:       answer.Upvotes,
+		Downvotes:     answer.Downvotes,
+		CanIDelete:    true,
+		IVoted:        0,
+	})
 }
 
 // @Summary		Delete an answer

--- a/api/images.go
+++ b/api/images.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/cartabinaria/auth/pkg/httputil"
 	"github.com/cartabinaria/auth/pkg/middleware"
-	"github.com/cartabinaria/polleg/models"
 	"github.com/cartabinaria/polleg/util"
 	"github.com/google/uuid"
 	"github.com/kataras/muxie"
@@ -34,6 +32,11 @@ const (
 	MAX_TOTAL_SIZE = 200 * 1024 * 1024 // 200 MB per user
 	MAX_NUMBER     = 100               // 100 images per user
 )
+
+type Image struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+}
 
 // checkFileType reads the first few bytes of a file and compares them with known signatures.
 // As it takes a reader as input, the caller should ensure to reset the reader's position if needed (e.g., using Seek).
@@ -91,7 +94,7 @@ func GetImageHandler(imagesPath string) http.HandlerFunc {
 // @Accept			multipart/form-data
 // @Param			image	formData	file	true	"Image to upload"
 // @Produce		json
-// @Success		200	{object}	models.ImageResponse
+// @Success		200	{object}	Image
 // @Failure		400	{object}	httputil.ApiError
 // @Router			/images [post]
 func PostImageHandler(imagesPath string) http.HandlerFunc {
@@ -221,8 +224,7 @@ func PostImageHandler(imagesPath string) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(models.ImageResponse{
+		httputil.WriteData(w, http.StatusOK, Image{
 			ID:  uuid.String(),
 			URL: fullPath,
 		})

--- a/api/question.go
+++ b/api/question.go
@@ -1,16 +1,16 @@
 package api
 
 import (
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 	"github.com/cartabinaria/auth/pkg/httputil"
 	"github.com/cartabinaria/auth/pkg/middleware"
 	"github.com/cartabinaria/polleg/models"
 	"github.com/cartabinaria/polleg/util"
 	"github.com/kataras/muxie"
 	"golang.org/x/exp/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -21,9 +21,9 @@ type Question struct {
 	UpdatedAt time.Time      `json:"updated_at"`
 	DeletedAt gorm.DeletedAt `json:"-"`
 
-	Document string           `json:"document"`
-	Start    uint32           `json:"start"`
-	End      uint32           `json:"end"`
+	Document string   `json:"document"`
+	Start    uint32   `json:"start"`
+	End      uint32   `json:"end"`
 	Answers  []Answer `json:"answers"`
 }
 

--- a/api/question.go
+++ b/api/question.go
@@ -4,21 +4,35 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
+	"time"
 	"github.com/cartabinaria/auth/pkg/httputil"
 	"github.com/cartabinaria/auth/pkg/middleware"
 	"github.com/cartabinaria/polleg/models"
 	"github.com/cartabinaria/polleg/util"
 	"github.com/kataras/muxie"
 	"golang.org/x/exp/slog"
+
+	"gorm.io/gorm"
 )
+
+type Question struct {
+	ID        uint           `json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `json:"-"`
+
+	Document string           `json:"document"`
+	Start    uint32           `json:"start"`
+	End      uint32           `json:"end"`
+	Answers  []Answer `json:"answers"`
+}
 
 // @Summary		Get all answers given a question
 // @Description	Given a question ID, return the question and all its answers
 // @Tags			question
 // @Param			id	path	string	true	"Answer id"
 // @Produce		json
-// @Success		200	{array}		models.QuestionResponse
+// @Success		200	{array}		Question
 // @Failure		400	{object}	httputil.ApiError
 // @Router			/questions/{id} [get]
 func GetQuestionHandler(res http.ResponseWriter, req *http.Request) {
@@ -72,7 +86,7 @@ func GetQuestionHandler(res http.ResponseWriter, req *http.Request) {
 	question.Answers = answers
 
 	// recursively convert answers
-	var responseAnswers []models.AnswerResponse
+	var responseAnswers []Answer
 	for _, ans := range question.Answers {
 		ans, err := ConvertAnswerToAPI(ans, isAdmin, requesterID)
 		if err != nil {
@@ -81,17 +95,15 @@ func GetQuestionHandler(res http.ResponseWriter, req *http.Request) {
 		responseAnswers = append(responseAnswers, *ans)
 	}
 
-	httputil.WriteData(res, http.StatusOK,
-		models.QuestionResponse{
-			ID:        question.ID,
-			CreatedAt: question.CreatedAt,
-			UpdatedAt: question.UpdatedAt,
-			Document:  question.Document,
-			Start:     question.Start,
-			End:       question.End,
-			Answers:   responseAnswers,
-		},
-	)
+	httputil.WriteData(res, http.StatusOK, Question{
+		ID:        question.ID,
+		CreatedAt: question.CreatedAt,
+		UpdatedAt: question.UpdatedAt,
+		Document:  question.Document,
+		Start:     question.Start,
+		End:       question.End,
+		Answers:   responseAnswers,
+	})
 }
 
 // @Summary		Delete a question

--- a/api/vote.go
+++ b/api/vote.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/cartabinaria/auth/pkg/httputil"
 	"github.com/cartabinaria/auth/pkg/middleware"
-	"github.com/cartabinaria/polleg/util"
 	"github.com/cartabinaria/polleg/models"
+	"github.com/cartabinaria/polleg/util"
 	"github.com/kataras/muxie"
 	"gorm.io/gorm/clause"
 )

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -45,7 +45,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.VoteResponse"
+                            "$ref": "#/definitions/api.Vote"
                         }
                     },
                     "400": {
@@ -82,7 +82,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.AnswerResponse"
+                            "$ref": "#/definitions/api.Answer"
                         }
                     },
                     "400": {
@@ -182,7 +182,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cartabinaria_polleg_models.AnswerResponse"
+                            "$ref": "#/definitions/api.Answer"
                         }
                     }
                 }
@@ -286,7 +286,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ImageResponse"
+                            "$ref": "#/definitions/api.Image"
                         }
                     },
                     "400": {
@@ -323,7 +323,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.QuestionResponse"
+                                "$ref": "#/definitions/api.Question"
                             }
                         }
                     },
@@ -368,6 +368,53 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.Answer": {
+            "type": "object",
+            "properties": {
+                "can_i_delete": {
+                    "type": "boolean"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "downvotes": {
+                    "type": "integer"
+                },
+                "i_voted": {
+                    "$ref": "#/definitions/api.VoteValue"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "parent": {
+                    "type": "integer"
+                },
+                "question": {
+                    "type": "integer"
+                },
+                "replies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Answer"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "upvotes": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "user_avatar_url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.Coord": {
             "type": "object",
             "properties": {
@@ -393,6 +440,17 @@ const docTemplate = `{
                 }
             }
         },
+        "api.Image": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.PostDocumentRequest": {
             "type": "object",
             "properties": {
@@ -407,52 +465,67 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_cartabinaria_polleg_models.AnswerResponse": {
+        "api.Question": {
             "type": "object",
             "properties": {
-                "can_i_delete": {
-                    "type": "boolean"
-                },
-                "content": {
-                    "type": "string"
+                "answers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Answer"
+                    }
                 },
                 "created_at": {
                     "type": "string"
                 },
-                "downvotes": {
-                    "type": "integer"
+                "document": {
+                    "type": "string"
                 },
-                "i_voted": {
+                "end": {
                     "type": "integer"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "parent": {
+                "start": {
                     "type": "integer"
-                },
-                "question": {
-                    "type": "integer"
-                },
-                "replies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
                 },
                 "updated_at": {
                     "type": "string"
-                },
-                "upvotes": {
+                }
+            }
+        },
+        "api.Vote": {
+            "type": "object",
+            "properties": {
+                "answer": {
                     "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 },
                 "user": {
                     "type": "string"
                 },
-                "user_avatar_url": {
-                    "type": "string"
+                "vote": {
+                    "type": "integer"
                 }
             }
+        },
+        "api.VoteValue": {
+            "type": "integer",
+            "enum": [
+                1,
+                0,
+                -1
+            ],
+            "x-enum-varnames": [
+                "VoteUp",
+                "VoteNone",
+                "VoteDown"
+            ]
         },
         "httputil.ApiError": {
             "type": "object",
@@ -501,56 +574,8 @@ const docTemplate = `{
                 }
             }
         },
-        "models.AnswerResponse": {
-            "type": "object",
-            "properties": {
-                "can_i_delete": {
-                    "type": "boolean"
-                },
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "downvotes": {
-                    "type": "integer"
-                },
-                "i_voted": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "parent": {
-                    "type": "integer"
-                },
-                "question": {
-                    "type": "integer"
-                },
-                "replies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "upvotes": {
-                    "type": "integer"
-                },
-                "user": {
-                    "type": "string"
-                },
-                "user_avatar_url": {
-                    "type": "string"
-                }
-            }
-        },
         "models.AnswerState": {
             "type": "integer",
-            "format": "int32",
             "enum": [
                 0,
                 1,
@@ -561,17 +586,6 @@ const docTemplate = `{
                 "AnswerStateDeletedByUser",
                 "AnswerStateDeletedByAdmin"
             ]
-        },
-        "models.ImageResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
         },
         "models.PostAnswerRequest": {
             "type": "object",
@@ -617,55 +631,6 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
-                }
-            }
-        },
-        "models.QuestionResponse": {
-            "type": "object",
-            "properties": {
-                "answers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "document": {
-                    "type": "string"
-                },
-                "end": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "start": {
-                    "type": "integer"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.VoteResponse": {
-            "type": "object",
-            "properties": {
-                "answer": {
-                    "type": "integer"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "user": {
-                    "type": "string"
-                },
-                "vote": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -38,7 +38,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.VoteResponse"
+                            "$ref": "#/definitions/api.Vote"
                         }
                     },
                     "400": {
@@ -75,7 +75,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.AnswerResponse"
+                            "$ref": "#/definitions/api.Answer"
                         }
                     },
                     "400": {
@@ -175,7 +175,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cartabinaria_polleg_models.AnswerResponse"
+                            "$ref": "#/definitions/api.Answer"
                         }
                     }
                 }
@@ -279,7 +279,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ImageResponse"
+                            "$ref": "#/definitions/api.Image"
                         }
                     },
                     "400": {
@@ -316,7 +316,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.QuestionResponse"
+                                "$ref": "#/definitions/api.Question"
                             }
                         }
                     },
@@ -361,6 +361,53 @@
         }
     },
     "definitions": {
+        "api.Answer": {
+            "type": "object",
+            "properties": {
+                "can_i_delete": {
+                    "type": "boolean"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "downvotes": {
+                    "type": "integer"
+                },
+                "i_voted": {
+                    "$ref": "#/definitions/api.VoteValue"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "parent": {
+                    "type": "integer"
+                },
+                "question": {
+                    "type": "integer"
+                },
+                "replies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Answer"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "upvotes": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "user_avatar_url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.Coord": {
             "type": "object",
             "properties": {
@@ -386,6 +433,17 @@
                 }
             }
         },
+        "api.Image": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.PostDocumentRequest": {
             "type": "object",
             "properties": {
@@ -400,52 +458,67 @@
                 }
             }
         },
-        "github_com_cartabinaria_polleg_models.AnswerResponse": {
+        "api.Question": {
             "type": "object",
             "properties": {
-                "can_i_delete": {
-                    "type": "boolean"
-                },
-                "content": {
-                    "type": "string"
+                "answers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Answer"
+                    }
                 },
                 "created_at": {
                     "type": "string"
                 },
-                "downvotes": {
-                    "type": "integer"
+                "document": {
+                    "type": "string"
                 },
-                "i_voted": {
+                "end": {
                     "type": "integer"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "parent": {
+                "start": {
                     "type": "integer"
-                },
-                "question": {
-                    "type": "integer"
-                },
-                "replies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
                 },
                 "updated_at": {
                     "type": "string"
-                },
-                "upvotes": {
+                }
+            }
+        },
+        "api.Vote": {
+            "type": "object",
+            "properties": {
+                "answer": {
                     "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
                 },
                 "user": {
                     "type": "string"
                 },
-                "user_avatar_url": {
-                    "type": "string"
+                "vote": {
+                    "type": "integer"
                 }
             }
+        },
+        "api.VoteValue": {
+            "type": "integer",
+            "enum": [
+                1,
+                0,
+                -1
+            ],
+            "x-enum-varnames": [
+                "VoteUp",
+                "VoteNone",
+                "VoteDown"
+            ]
         },
         "httputil.ApiError": {
             "type": "object",
@@ -494,56 +567,8 @@
                 }
             }
         },
-        "models.AnswerResponse": {
-            "type": "object",
-            "properties": {
-                "can_i_delete": {
-                    "type": "boolean"
-                },
-                "content": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "downvotes": {
-                    "type": "integer"
-                },
-                "i_voted": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "parent": {
-                    "type": "integer"
-                },
-                "question": {
-                    "type": "integer"
-                },
-                "replies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "upvotes": {
-                    "type": "integer"
-                },
-                "user": {
-                    "type": "string"
-                },
-                "user_avatar_url": {
-                    "type": "string"
-                }
-            }
-        },
         "models.AnswerState": {
             "type": "integer",
-            "format": "int32",
             "enum": [
                 0,
                 1,
@@ -554,17 +579,6 @@
                 "AnswerStateDeletedByUser",
                 "AnswerStateDeletedByAdmin"
             ]
-        },
-        "models.ImageResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
         },
         "models.PostAnswerRequest": {
             "type": "object",
@@ -610,55 +624,6 @@
                 },
                 "updated_at": {
                     "type": "string"
-                }
-            }
-        },
-        "models.QuestionResponse": {
-            "type": "object",
-            "properties": {
-                "answers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AnswerResponse"
-                    }
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "document": {
-                    "type": "string"
-                },
-                "end": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "start": {
-                    "type": "integer"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.VoteResponse": {
-            "type": "object",
-            "properties": {
-                "answer": {
-                    "type": "integer"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "user": {
-                    "type": "string"
-                },
-                "vote": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,36 @@
 basePath: /
 definitions:
+  api.Answer:
+    properties:
+      can_i_delete:
+        type: boolean
+      content:
+        type: string
+      created_at:
+        type: string
+      downvotes:
+        type: integer
+      i_voted:
+        $ref: '#/definitions/api.VoteValue'
+      id:
+        type: integer
+      parent:
+        type: integer
+      question:
+        type: integer
+      replies:
+        items:
+          $ref: '#/definitions/api.Answer'
+        type: array
+      updated_at:
+        type: string
+      upvotes:
+        type: integer
+      user:
+        type: string
+      user_avatar_url:
+        type: string
+    type: object
   api.Coord:
     properties:
       end:
@@ -16,6 +47,13 @@ definitions:
           $ref: '#/definitions/models.Question'
         type: array
     type: object
+  api.Image:
+    properties:
+      id:
+        type: string
+      url:
+        type: string
+    type: object
   api.PostDocumentRequest:
     properties:
       coords:
@@ -25,37 +63,48 @@ definitions:
       id:
         type: string
     type: object
-  github_com_cartabinaria_polleg_models.AnswerResponse:
+  api.Question:
     properties:
-      can_i_delete:
-        type: boolean
-      content:
-        type: string
+      answers:
+        items:
+          $ref: '#/definitions/api.Answer'
+        type: array
       created_at:
         type: string
-      downvotes:
-        type: integer
-      i_voted:
+      document:
+        type: string
+      end:
         type: integer
       id:
         type: integer
-      parent:
+      start:
         type: integer
-      question:
-        type: integer
-      replies:
-        items:
-          $ref: '#/definitions/models.AnswerResponse'
-        type: array
       updated_at:
         type: string
-      upvotes:
+    type: object
+  api.Vote:
+    properties:
+      answer:
         type: integer
+      createdAt:
+        type: string
+      updatedAt:
+        type: string
       user:
         type: string
-      user_avatar_url:
-        type: string
+      vote:
+        type: integer
     type: object
+  api.VoteValue:
+    enum:
+    - 1
+    - 0
+    - -1
+    type: integer
+    x-enum-varnames:
+    - VoteUp
+    - VoteNone
+    - VoteDown
   httputil.ApiError:
     properties:
       error:
@@ -87,55 +136,16 @@ definitions:
       upvotes:
         type: integer
     type: object
-  models.AnswerResponse:
-    properties:
-      can_i_delete:
-        type: boolean
-      content:
-        type: string
-      created_at:
-        type: string
-      downvotes:
-        type: integer
-      i_voted:
-        type: integer
-      id:
-        type: integer
-      parent:
-        type: integer
-      question:
-        type: integer
-      replies:
-        items:
-          $ref: '#/definitions/models.AnswerResponse'
-        type: array
-      updated_at:
-        type: string
-      upvotes:
-        type: integer
-      user:
-        type: string
-      user_avatar_url:
-        type: string
-    type: object
   models.AnswerState:
     enum:
     - 0
     - 1
     - 2
-    format: int32
     type: integer
     x-enum-varnames:
     - AnswerStateVisible
     - AnswerStateDeletedByUser
     - AnswerStateDeletedByAdmin
-  models.ImageResponse:
-    properties:
-      id:
-        type: string
-      url:
-        type: string
-    type: object
   models.PostAnswerRequest:
     properties:
       anonymous:
@@ -167,38 +177,6 @@ definitions:
       updated_at:
         type: string
     type: object
-  models.QuestionResponse:
-    properties:
-      answers:
-        items:
-          $ref: '#/definitions/models.AnswerResponse'
-        type: array
-      created_at:
-        type: string
-      document:
-        type: string
-      end:
-        type: integer
-      id:
-        type: integer
-      start:
-        type: integer
-      updated_at:
-        type: string
-    type: object
-  models.VoteResponse:
-    properties:
-      answer:
-        type: integer
-      createdAt:
-        type: string
-      updatedAt:
-        type: string
-      user:
-        type: string
-      vote:
-        type: integer
-    type: object
 info:
   contact:
     email: gabriele.genovese2@studio.unibo.it
@@ -226,7 +204,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.VoteResponse'
+            $ref: '#/definitions/api.Vote'
         "400":
           description: Bad Request
           schema:
@@ -250,7 +228,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.AnswerResponse'
+            $ref: '#/definitions/api.Answer'
         "400":
           description: Bad Request
           schema:
@@ -316,7 +294,7 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_cartabinaria_polleg_models.AnswerResponse'
+            $ref: '#/definitions/api.Answer'
       summary: Get answer replies
       tags:
       - answer
@@ -384,7 +362,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ImageResponse'
+            $ref: '#/definitions/api.Image'
         "400":
           description: Bad Request
           schema:
@@ -428,7 +406,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.QuestionResponse'
+              $ref: '#/definitions/api.Question'
             type: array
         "400":
           description: Bad Request

--- a/models/model.go
+++ b/models/model.go
@@ -90,56 +90,6 @@ type UpdateAnswerRequest struct {
 	Content string `json:"content"`
 }
 
-type AnswerResponse struct {
-	ID        uint      `json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-
-	Question uint  `json:"question"`
-	Parent   *uint `json:"parent"`
-
-	User          string           `json:"user"`
-	UserAvatarURL string           `json:"user_avatar_url"`
-	Content       string           `json:"content"`
-	Upvotes       uint32           `json:"upvotes"`
-	Downvotes     uint32           `json:"downvotes"`
-	Replies       []AnswerResponse `json:"replies"`
-	CanIDelete    bool             `json:"can_i_delete"`
-	IVoted        VoteValue        `json:"i_voted"`
-}
-
-type VoteValue int8
-
-type PostVoteRequest struct {
-	Vote VoteValue `json:"vote"`
-}
-
-type VoteResponse struct {
-	Answer uint   `json:"answer"`
-	User   string `json:"user"`
-	Vote   int8   `json:"vote"`
-
-	CreatedAt time.Time
-	UpdatedAt time.Time
-}
-
-type QuestionResponse struct {
-	ID        uint           `json:"id"`
-	CreatedAt time.Time      `json:"created_at"`
-	UpdatedAt time.Time      `json:"updated_at"`
-	DeletedAt gorm.DeletedAt `json:"-"`
-
-	Document string           `json:"document"`
-	Start    uint32           `json:"start"`
-	End      uint32           `json:"end"`
-	Answers  []AnswerResponse `json:"answers"`
-}
-
-type ImageResponse struct {
-	ID  string `json:"id"`
-	URL string `json:"url"`
-}
-
 type Image struct {
 	ID        string `gorm:"primarykey"`
 	CreatedAt time.Time


### PR DESCRIPTION
While scanning through the code I saw that API response types where defined in `models`, which should hold the DB structures. I think defining the API types in there is bad practice, we want to have separation between the internal data structures and what's exposed in the API.

This PR does some refactoring and moves all structures defined in models that belong to the API interface in the api package.
I have a feeling (but didn't check) the types in model are also being directly JSON serialized (I get this feeling from the inlining of the `gorm.Model` struct). This should also be avoided for the same reason as before.
I think that kind of refactoring can probably be done by claude code/gemini without human intervention, but I didn't bother for this PR.

As a side note: What is the purpose of `AnswerVersions`? why is the name plural? I assume the `Answer` field is a reference to the Answer ID column. Shouldn't it be marked as such in SQL through gorm annotations?


This is just me raising what are clearly nits. If code quality is not a priority right now, just ignore them and feel free to close this PR :) 